### PR TITLE
fix: cleanup registered player handle of death

### DIFF
--- a/Source/Tarkov/RegisteredPlayers.cs
+++ b/Source/Tarkov/RegisteredPlayers.cs
@@ -361,48 +361,26 @@ namespace eft_dma_radar
                     if (player.LastUpdate) // player may be dead/exfil'd
                     {
                         var doChams = Program.Config.MasterSwitch && Program.Config.Chams["Enabled"];
+                        var logMessage = player.Position == DEFAULT_POSITION ? "exfiltrated" : "died";
 
-                        if (player.Position == DEFAULT_POSITION)
+                        if (doChams)
                         {
-
-                            player.IsActive = false;
-                            Program.Log($"{player.Name} exfiltrated");
-
-                            if (doChams)
-                                Memory.Chams.RemovePointersForPlayer(player);
-                        }
-                        else
-                        {
-                            if (player.Position == DEFAULT_POSITION)
+                            if (player.IsLocalPlayer)
                             {
-
-                                player.IsActive = false;
-                                Program.Log($"{player.Name} exfiltrated");
-
-                                Memory.Chams.RemovePointersForPlayer(player);
+                                Memory.Chams.RestorePointers();
+                                Program.Log("LocalPlayer has died!");
                             }
                             else
                             {
-                                if (doChams)
-                                {
-                                    if (player.IsLocalPlayer)
-                                    {
-                                        Memory.Chams.RestorePointers();
-                                        Program.Log("LocalPlayer has died!");
-                                    }
-                                    else
-                                    {
-                                        if (Program.Config.Chams["Corpses"])
-                                            Memory.Chams.SetPlayerBodyChams(player, Memory.Chams.ThermalMaterial);
-                                        else
-                                            Memory.Chams.RestorePointersForPlayer(player);
-                                    }
-                                }
-
-                                player.IsAlive = false;
-                                Program.Log($"{player.Name} died");
+                                if (Program.Config.Chams["Corpses"])
+                                    Memory.Chams.SetPlayerBodyChams(player, Memory.Chams.ThermalMaterial);
+                                else
+                                    Memory.Chams.RestorePointersForPlayer(player);
                             }
                         }
+
+                        player.IsActive = false;
+                        Program.Log($"{player.Name} {logMessage}");
 
                         player.LastUpdate = false;
                     }


### PR DESCRIPTION
**This code has not been tested as I dont have the dma card yet**

Build is success
I tried to clean the code a bit according to my understanding but I could have made mistakes.
I also wonder about the `player.LastUpdate = false;` at line 385 which was in the current code.

To my understanding, this boolean is true when the player died/exfil and this part of the code handle it and remove chams / print his death or exfil state so I dont get why we set it to true after this (explanation welcome !)